### PR TITLE
Fix the mandatory fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "eblint"
-version = "0.0.1"
+version = "0.0.2"
 authors = [{ name = "Leon Boschman", email = "leon.boschman@chalmers.se" }]
 description = "A linter for easybuild config files"
 readme = "README.md"

--- a/src/eblint/checkers/default_checkers.py
+++ b/src/eblint/checkers/default_checkers.py
@@ -6,14 +6,14 @@ from .last_field_checker import LastFieldChecker
 _default_mandatory_field_checker = MandatoryFieldChecker(
     issue_code="M001",
     field_names=[
-        "easyblock",
         "name",
         "version",
         "homepage",
         "description",
-        "dependencies",
-        "builddependencies",
         "toolchain",
+        # moduleclass is taken care of by M004.
+        # If M004 gets removed, uncomment the line below
+        # "moduleclass",
     ],
 )
 

--- a/tests/testfiles/linter/fail/M001/two-missing-fields.eb
+++ b/tests/testfiles/linter/fail/M001/two-missing-fields.eb
@@ -5,12 +5,12 @@ version = '1.15.0'
 versionsuffix = '-CUDA-%(cudaver)s'
 foo = "bar"
 homepage = 'http://www.openucx.org/'
-description = """Unified Communication X
-An open-source production grade communication framework for data centric
-and high-performance applications
-
-This module adds the UCX CUDA support.
-"""
+# description = """Unified Communication X
+# An open-source production grade communication framework for data centric
+# and high-performance applications
+# 
+# This module adds the UCX CUDA support.
+# """
 
 # toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
 toolchainopts = {'pic': True}
@@ -38,4 +38,4 @@ dependencies = [
 ]
 
 
-# moduleclass = 'lib'
+moduleclass = 'lib'

--- a/tests/testfiles/linter/fail/M001/two-missing-fields.eb
+++ b/tests/testfiles/linter/fail/M001/two-missing-fields.eb
@@ -30,12 +30,12 @@ builddependencies = [
     ('pkgconf', '2.0.3'),
 ]
 
-# dependencies = [
-#     ('zlib', '1.2.13'),
-#     ('UCX', version),
-#     ('CUDA', '12.5.0', '', SYSTEM),
-#     ('GDRCopy', '2.4'),
-# ]
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('UCX', version),
+    ('CUDA', '12.5.0', '', SYSTEM),
+    ('GDRCopy', '2.4'),
+]
 
 
-moduleclass = 'lib'
+# moduleclass = 'lib'

--- a/tests/testfiles/linter/pass/no-field-easyblock-pass.eb
+++ b/tests/testfiles/linter/pass/no-field-easyblock-pass.eb
@@ -1,0 +1,39 @@
+name = 'UCX-CUDA'
+version = '1.15.0'
+versionsuffix = '-CUDA-%(cudaver)s'
+foo = "bar"
+homepage = 'http://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+
+This module adds the UCX CUDA support.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '13.2.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = [{'filename': 'ucx-%(version)s.tar.gz', 'alt_location': 'UCX'}]
+patches = ['%(name)s-1.11.0_link_against_existing_UCX_libs.patch']
+checksums = [
+    {'ucx-1.15.0.tar.gz': '4b202087076bc1c98f9249144f0c277a8ea88ad4ca6f404f94baa9cb3aebda6d'},
+    {'UCX-CUDA-1.11.0_link_against_existing_UCX_libs.patch':
+     '457187fa020e526609ba91e7750c9941d57bd57d60d6eed317b40ad8824aca93'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+    ('Autotools', '202217'),
+    ('pkgconf', '2.0.3'),
+]
+
+dependencies = [
+    ('zlib', '1.2.13'),
+    ('UCX', version),
+    ('CUDA', '12.5.0', '', SYSTEM),
+    ('GDRCopy', '2.4'),
+]
+
+
+moduleclass = 'lib'


### PR DESCRIPTION
The mandatory fields should now be fixed.
Removed mandatory fields:
- `easyblock`
- `dependencies`
- `builddependencies`

The mandatory field `moduleclass` is already taken care of by M004.
This PR fixes issue #6 .