### PR TITLE
Add filename path to ast-parser

### DIFF
--- a/src/eblint/linter.py
+++ b/src/eblint/linter.py
@@ -55,7 +55,7 @@ class Linter:
         with open(source_path, "r") as source_file:
             source_code = source_file.read()
 
-        tree = ast.parse(source_code)
+        tree = ast.parse(source_code, filename=source_path)
         for checker in self.checkers:
             checker.visit(tree)
             self.print_violations(checker, source_path)


### PR DESCRIPTION
This way any python syntax warnings/errors will be displayed correctly by the AST parser